### PR TITLE
content type needs to be xhtml for xhtml content

### DIFF
--- a/src/content.rs
+++ b/src/content.rs
@@ -154,7 +154,7 @@ impl ToXml for Content {
 
         if let Some(ref content_type) = self.content_type {
             if content_type == "xhtml" {
-                element.push_attribute(("type", "html"));
+                element.push_attribute(("type", "xhtml"));
             } else {
                 element.push_attribute(("type", &**content_type));
             }


### PR DESCRIPTION
As can be checked with https://validator.w3.org/feed/check.cgi when the content type is xhtml, it should be specified as xhtml and not as html.