### PR TITLE
prevent mixed content warning on crates.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # atom
 
 [![Build Status](https://travis-ci.org/rust-syndication/atom.svg?branch=master)](https://travis-ci.org/rust-syndication/atom)
-[![Crates.io Status](http://meritbadge.herokuapp.com/atom_syndication)](https://crates.io/crates/atom_syndication)
+[![Crates.io Status](	https://img.shields.io/crates/v/atom_syndication.svg)](https://crates.io/crates/atom_syndication)
 
 Library for serializing the Atom web content syndication format.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # atom
 
 [![Build Status](https://travis-ci.org/rust-syndication/atom.svg?branch=master)](https://travis-ci.org/rust-syndication/atom)
-[![Crates.io Status](	https://img.shields.io/crates/v/atom_syndication.svg)](https://crates.io/crates/atom_syndication)
+[![Crates.io Status](https://img.shields.io/crates/v/atom_syndication.svg)](https://crates.io/crates/atom_syndication)
 
 Library for serializing the Atom web content syndication format.
 


### PR DESCRIPTION
Loading this image via http creates a "mixed content" warning in browsers when reading the README on crates.io. Its a minor problem, but at the same time pretty easy to fix. 

I opted for using shields.io directly here since meritbadge.herokuapp redirects there anyway. Another solution would be to keep using the mertibadge URL but add an `s` to the scheme. It seems to support https, too. 