### PR TITLE
Use thiserror instead of failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ include = ["src/*", "Cargo.toml", "LICENSE-MIT", "LICENSE-APACHE", "README.md"]
 quick-xml = { version = "0.17", features = ["encoding"] }
 derive_builder = "0.9"
 serde = { version = "1.0", optional = true, features = ["derive"] }
-failure = "0.1"
 chrono = "0.4"
+thiserror = "1.0"
 
 [features]
 with-serde = ["serde", "chrono/serde"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,38 +1,24 @@
 use std::str::Utf8Error;
 
 use quick_xml::Error as XmlError;
+use thiserror::Error;
 
-#[derive(Debug, Fail)]
+#[derive(Debug, Error)]
 /// An error that occurred while performing an Atom operation.
 pub enum Error {
     /// Unable to parse XML.
-    #[fail(display = "{}", _0)]
-    Xml(#[cause] XmlError),
+    #[error("{0}")]
+    Xml(#[from] XmlError),
     /// Unable to parse UTF8 in to a string.
-    #[fail(display = "{}", _0)]
-    Utf8(#[cause] Utf8Error),
+    #[error("{0}")]
+    Utf8(#[from] Utf8Error),
     /// Input did not begin with an opening feed tag.
-    #[fail(display = "input did not begin with an opening feed tag")]
+    #[error("input did not begin with an opening feed tag")]
     InvalidStartTag,
     /// Unexpected end of input.
-    #[fail(display = "unexpected end of input")]
+    #[error("unexpected end of input")]
     Eof,
     /// The format of the timestamp is wrong.
-    #[fail(
-        display = "timestamps must be formatted by RFC3339, rather than {}",
-        _0
-    )]
+    #[error("timestamps must be formatted by RFC3339, rather than {0}")]
     WrongDatetime(String),
-}
-
-impl From<XmlError> for Error {
-    fn from(err: XmlError) -> Error {
-        Error::Xml(err)
-    }
-}
-
-impl From<Utf8Error> for Error {
-    fn from(err: Utf8Error) -> Error {
-        Error::Utf8(err)
-    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,9 +51,6 @@ extern crate serde;
 #[macro_use]
 extern crate derive_builder;
 
-#[macro_use]
-extern crate failure;
-
 extern crate quick_xml;
 
 extern crate chrono;


### PR DESCRIPTION
`failure` seems to have fallen out of fashion in favor of std::error::Error complaint crates. `thiserror` seems to be the best option at the moment.