### PR TITLE
Handwrite Error conformance so thiserror is not needed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ quick-xml = { version = "0.17", features = ["encoding"] }
 derive_builder = "0.9"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 chrono = "0.4"
-thiserror = "1.0"
 
 [features]
 with-serde = ["serde", "chrono/serde"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,7 +20,7 @@ pub enum Error {
 }
 
 impl StdError for Error {
-    fn cause(&self) -> Option<&dyn StdError> {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match *self {
             Error::Xml(ref err) => Some(err),
             Error::Utf8(ref err) => Some(err),
@@ -34,8 +34,8 @@ impl StdError for Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::Xml(ref err) => err.fmt(f),
-            Error::Utf8(ref err) => err.fmt(f),
+            Error::Xml(ref err) => fmt::Display::fmt(err, f),
+            Error::Utf8(ref err) => fmt::Display::fmt(err, f),
             Error::InvalidStartTag => write!(f, "input did not begin with an opening feed tag"),
             Error::Eof => write!(f, "unexpected end of input"),
             Error::WrongDatetime(ref datetime) => write!(

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,24 +1,59 @@
+use std::error::Error as StdError;
+use std::fmt;
 use std::str::Utf8Error;
 
 use quick_xml::Error as XmlError;
-use thiserror::Error;
 
-#[derive(Debug, Error)]
+#[derive(Debug)]
 /// An error that occurred while performing an Atom operation.
 pub enum Error {
     /// Unable to parse XML.
-    #[error("{0}")]
-    Xml(#[from] XmlError),
+    Xml(XmlError),
     /// Unable to parse UTF8 in to a string.
-    #[error("{0}")]
-    Utf8(#[from] Utf8Error),
+    Utf8(Utf8Error),
     /// Input did not begin with an opening feed tag.
-    #[error("input did not begin with an opening feed tag")]
     InvalidStartTag,
     /// Unexpected end of input.
-    #[error("unexpected end of input")]
     Eof,
     /// The format of the timestamp is wrong.
-    #[error("timestamps must be formatted by RFC3339, rather than {0}")]
     WrongDatetime(String),
+}
+
+impl StdError for Error {
+    fn cause(&self) -> Option<&dyn StdError> {
+        match *self {
+            Error::Xml(ref err) => Some(err),
+            Error::Utf8(ref err) => Some(err),
+            Error::InvalidStartTag => None,
+            Error::Eof => None,
+            Error::WrongDatetime(_) => None,
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::Xml(ref err) => err.fmt(f),
+            Error::Utf8(ref err) => err.fmt(f),
+            Error::InvalidStartTag =>
+                write!(f, "input did not begin with an opening feed tag"),
+            Error::Eof =>
+                write!(f, "unexpected end of input"),
+            Error::WrongDatetime(ref datetime) =>
+                write!(f, "timestamps must be formatted by RFC3339, rather than {}", datetime),
+        }
+    }
+}
+
+impl From<XmlError> for Error {
+    fn from(err: XmlError) -> Error {
+        Error::Xml(err)
+    }
+}
+
+impl From<Utf8Error> for Error {
+    fn from(err: Utf8Error) -> Error {
+        Error::Utf8(err)
+    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,12 +36,13 @@ impl fmt::Display for Error {
         match *self {
             Error::Xml(ref err) => err.fmt(f),
             Error::Utf8(ref err) => err.fmt(f),
-            Error::InvalidStartTag =>
-                write!(f, "input did not begin with an opening feed tag"),
-            Error::Eof =>
-                write!(f, "unexpected end of input"),
-            Error::WrongDatetime(ref datetime) =>
-                write!(f, "timestamps must be formatted by RFC3339, rather than {}", datetime),
+            Error::InvalidStartTag => write!(f, "input did not begin with an opening feed tag"),
+            Error::Eof => write!(f, "unexpected end of input"),
+            Error::WrongDatetime(ref datetime) => write!(
+                f,
+                "timestamps must be formatted by RFC3339, rather than {}",
+                datetime
+            ),
         }
     }
 }


### PR DESCRIPTION
rust-syndication/atom#17 removed `failure` and instead just conformed `Error` to `std::error::Error`, which seems like a great change. Before seeing that change, I worked on a similar change for `rss` in rust-syndication/rss#82, although my approach turned out to be slightly different.

`thiserror` was used to implement the trait here, and while it seems like an awesome crate, I'm not sure the convenience is worth it for the cost of adding additional dependencies. Every dependency to this crate means more crates that users have to download, more versions for them to deal with, and longer compile times.

I handwrote an implementation of the trait, and while it's definitely more boilerplate, I don't think the ~30 extra lines are much of a maintenance burden, and it seems worth it to mean one less dependency in users' lockfiles.