### PR TITLE
Add a default builders feature that can be disabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ rust:
 
 script:
   - rustup component add rustfmt clippy
+  - cargo build --all-targets --no-default-features --verbose
   - cargo build --all-targets --verbose
   - cargo test --all-targets --verbose
   - cargo clippy --all-targets --all-features -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,11 @@ include = ["src/*", "Cargo.toml", "LICENSE-MIT", "LICENSE-APACHE", "README.md"]
 
 [dependencies]
 quick-xml = { version = "0.17", features = ["encoding"] }
-derive_builder = "0.9"
+derive_builder = { version = "0.9", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 chrono = "0.4"
 
 [features]
+default = ["builders"]
+builders = ["derive_builder"]
 with-serde = ["serde", "chrono/serde"]

--- a/src/category.rs
+++ b/src/category.rs
@@ -12,8 +12,9 @@ use crate::toxml::ToXml;
 
 /// Represents a category in an Atom feed
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[derive(Debug, Default, Clone, PartialEq, Builder)]
-#[builder(setter(into), default)]
+#[derive(Debug, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "builders", derive(Builder))]
+#[cfg_attr(feature = "builders", builder(setter(into), default))]
 pub struct Category {
     /// Identifies the category.
     term: String,

--- a/src/content.rs
+++ b/src/content.rs
@@ -13,8 +13,9 @@ use crate::util::atom_any_text;
 
 /// Represents the content of an Atom entry
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[derive(Debug, Default, Clone, PartialEq, Builder)]
-#[builder(setter(into), default)]
+#[derive(Debug, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "builders", derive(Builder))]
+#[cfg_attr(feature = "builders", builder(setter(into), default))]
 pub struct Content {
     /// The text value of the content.
     value: Option<String>,

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -20,8 +20,9 @@ use crate::util::{atom_datetime, atom_text, default_fixed_datetime, FixedDateTim
 
 /// Represents an entry in an Atom feed
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[derive(Debug, Clone, PartialEq, Builder)]
-#[builder(setter(into), default)]
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "builders", derive(Builder))]
+#[cfg_attr(feature = "builders", builder(setter(into), default))]
 pub struct Entry {
     /// A human-readable title for the entry.
     title: String,

--- a/src/extension/mod.rs
+++ b/src/extension/mod.rs
@@ -15,8 +15,9 @@ pub type ExtensionMap = HashMap<String, HashMap<String, Vec<Extension>>>;
 
 /// A namespaced extension.
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[derive(Debug, Default, Clone, PartialEq, Builder)]
-#[builder(setter(into), default)]
+#[derive(Debug, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "builders", derive(Builder))]
+#[cfg_attr(feature = "builders", builder(setter(into), default))]
 pub struct Extension {
     /// The qualified name of the extension element.
     name: String,

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -22,8 +22,9 @@ use crate::util::{atom_any_text, atom_datetime, atom_text, default_fixed_datetim
 
 /// Represents an Atom feed
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[derive(Debug, Clone, PartialEq, Builder)]
-#[builder(setter(into), default)]
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "builders", derive(Builder))]
+#[cfg_attr(feature = "builders", builder(setter(into), default))]
 pub struct Feed {
     /// A human-readable title for the feed.
     title: String,

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -13,8 +13,9 @@ use crate::util::atom_text;
 
 /// Represents the generator of an Atom feed
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[derive(Debug, Default, Clone, PartialEq, Builder)]
-#[builder(setter(into), default)]
+#[derive(Debug, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "builders", derive(Builder))]
+#[cfg_attr(feature = "builders", builder(setter(into), default))]
 pub struct Generator {
     /// The name of the generator.
     value: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@
 #[macro_use]
 extern crate serde;
 
+#[cfg(feature = "builders")]
 #[macro_use]
 extern crate derive_builder;
 
@@ -72,13 +73,29 @@ mod util;
 /// Types and functions for namespaced extensions.
 pub mod extension;
 
-pub use crate::category::{Category, CategoryBuilder};
-pub use crate::content::{Content, ContentBuilder};
-pub use crate::entry::{Entry, EntryBuilder};
+pub use crate::category::Category;
+#[cfg(feature = "builders")]
+pub use crate::category::CategoryBuilder;
+pub use crate::content::Content;
+#[cfg(feature = "builders")]
+pub use crate::content::ContentBuilder;
+pub use crate::entry::Entry;
+#[cfg(feature = "builders")]
+pub use crate::entry::EntryBuilder;
 pub use crate::error::Error;
-pub use crate::feed::{Feed, FeedBuilder};
-pub use crate::generator::{Generator, GeneratorBuilder};
-pub use crate::link::{Link, LinkBuilder};
-pub use crate::person::{Person, PersonBuilder};
-pub use crate::source::{Source, SourceBuilder};
+pub use crate::feed::Feed;
+#[cfg(feature = "builders")]
+pub use crate::feed::FeedBuilder;
+pub use crate::generator::Generator;
+#[cfg(feature = "builders")]
+pub use crate::generator::GeneratorBuilder;
+pub use crate::link::Link;
+#[cfg(feature = "builders")]
+pub use crate::link::LinkBuilder;
+pub use crate::person::Person;
+#[cfg(feature = "builders")]
+pub use crate::person::PersonBuilder;
+pub use crate::source::Source;
+#[cfg(feature = "builders")]
+pub use crate::source::SourceBuilder;
 pub use crate::util::FixedDateTime;

--- a/src/link.rs
+++ b/src/link.rs
@@ -12,8 +12,9 @@ use crate::toxml::ToXml;
 
 /// Represents a link in an Atom feed
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[derive(Debug, Clone, PartialEq, Builder)]
-#[builder(setter(into), default)]
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "builders", derive(Builder))]
+#[cfg_attr(feature = "builders", builder(setter(into), default))]
 pub struct Link {
     /// The URI of the referenced resource.
     href: String,

--- a/src/person.rs
+++ b/src/person.rs
@@ -13,8 +13,9 @@ use crate::util::atom_text;
 
 /// Represents a person in an Atom feed
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[derive(Debug, Default, Clone, PartialEq, Builder)]
-#[builder(setter(into), default)]
+#[derive(Debug, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "builders", derive(Builder))]
+#[cfg_attr(feature = "builders", builder(setter(into), default))]
 pub struct Person {
     /// A human-readable name for the person.
     name: String,

--- a/src/source.rs
+++ b/src/source.rs
@@ -17,8 +17,9 @@ use crate::util::{atom_datetime, atom_text, default_fixed_datetime, FixedDateTim
 
 /// Represents the source of an Atom entry
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[derive(Debug, Clone, PartialEq, Builder)]
-#[builder(setter(into), default)]
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "builders", derive(Builder))]
+#[cfg_attr(feature = "builders", builder(setter(into), default))]
 pub struct Source {
     /// A human-readable title for the feed.
     title: String,


### PR DESCRIPTION
The `atom_syndication` crate depends on `derive_builder` to generate convenient builders for creating the contents of an atom feed. However, for users that only want to parse an atom feed, not create their own, this results in 12 additional dependencies, some of which are pretty heavy.

This change adds a `builders` feature to the crate which is enabled by default. When disabled, though, none of the builders are included in the crate, and the `derive_builder` dependency is omitted. This should be a backwards-compatible way that users can opt for having lighter dependencies.

While more features and cfg attributes always add complexity to code, I think this comes out pretty manageable. I added a step to the travis tests to ensure that the crate compiles with and without the feature.