### PR TITLE
Expose all fields of the model types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ rust:
   - beta
   - stable
 
+jobs:
+  allow_failures:
+    - rust: nightly
+
 script:
   - rustup component add rustfmt clippy
   - cargo build --all-targets --no-default-features --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rust:
   - nightly
   - beta
   - stable
+  - 1.40.0
 
 jobs:
   allow_failures:

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Library for serializing the Atom web content syndication format.
 
 [Documentation](https://docs.rs/atom_syndication/)
 
+This crate requires *Rustc version 1.40.0 or greater*.
+
 ## Usage
 
 Add the dependency to your `Cargo.toml`.

--- a/src/category.rs
+++ b/src/category.rs
@@ -69,7 +69,7 @@ impl Category {
     /// assert_eq!(category.scheme(), Some("http://example.com/scheme"));
     /// ```
     pub fn scheme(&self) -> Option<&str> {
-        self.scheme.as_ref().map(String::as_str)
+        self.scheme.as_deref()
     }
 
     /// Set the categorization scheme URI.
@@ -102,7 +102,7 @@ impl Category {
     /// ```
 
     pub fn label(&self) -> Option<&str> {
-        self.label.as_ref().map(String::as_str)
+        self.label.as_deref()
     }
 
     /// Set the label for this category.
@@ -124,7 +124,10 @@ impl Category {
 }
 
 impl FromXml for Category {
-    fn from_xml<B: BufRead>(reader: &mut Reader<B>, mut atts: Attributes) -> Result<Self, Error> {
+    fn from_xml<B: BufRead>(
+        reader: &mut Reader<B>,
+        mut atts: Attributes<'_>,
+    ) -> Result<Self, Error> {
         let mut category = Category::default();
 
         for attr in atts.with_checks(false) {

--- a/src/category.rs
+++ b/src/category.rs
@@ -17,11 +17,11 @@ use crate::toxml::ToXml;
 #[cfg_attr(feature = "builders", builder(setter(into), default))]
 pub struct Category {
     /// Identifies the category.
-    term: String,
+    pub term: String,
     /// Identifies the categorization scheme via a URI.
-    scheme: Option<String>,
+    pub scheme: Option<String>,
     /// A human-readable label for display.
-    label: Option<String>,
+    pub label: Option<String>,
 }
 
 impl Category {

--- a/src/content.rs
+++ b/src/content.rs
@@ -18,11 +18,11 @@ use crate::util::atom_any_text;
 #[cfg_attr(feature = "builders", builder(setter(into), default))]
 pub struct Content {
     /// The text value of the content.
-    value: Option<String>,
+    pub value: Option<String>,
     /// The URI of where the content can be found.
-    src: Option<String>,
+    pub src: Option<String>,
     /// Either "text", "html", "xhtml", or the MIME type of the content.
-    content_type: Option<String>,
+    pub content_type: Option<String>,
 }
 
 impl Content {

--- a/src/content.rs
+++ b/src/content.rs
@@ -41,7 +41,7 @@ impl Content {
     /// assert_eq!(content.value(), Some("Example content"));
     /// ```
     pub fn value(&self) -> Option<&str> {
-        self.value.as_ref().map(String::as_str)
+        self.value.as_deref()
     }
 
     /// Set the text value of the content.
@@ -73,7 +73,7 @@ impl Content {
     /// assert_eq!(content.src(), Some("http://example.com/content.html"));
     /// ```
     pub fn src(&self) -> Option<&str> {
-        self.src.as_ref().map(String::as_str)
+        self.src.as_deref()
     }
 
     /// Set the URI where the content can be found.
@@ -107,7 +107,7 @@ impl Content {
     /// assert_eq!(content.content_type(), Some("image/png"));
     /// ```
     pub fn content_type(&self) -> Option<&str> {
-        self.content_type.as_ref().map(String::as_str)
+        self.content_type.as_deref()
     }
 
     /// Set the type of the content.
@@ -130,7 +130,10 @@ impl Content {
 }
 
 impl FromXml for Content {
-    fn from_xml<B: BufRead>(reader: &mut Reader<B>, mut atts: Attributes) -> Result<Self, Error> {
+    fn from_xml<B: BufRead>(
+        reader: &mut Reader<B>,
+        mut atts: Attributes<'_>,
+    ) -> Result<Self, Error> {
         let mut content = Content::default();
 
         for attr in atts.with_checks(false) {

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -25,31 +25,31 @@ use crate::util::{atom_datetime, atom_text, default_fixed_datetime, FixedDateTim
 #[cfg_attr(feature = "builders", builder(setter(into), default))]
 pub struct Entry {
     /// A human-readable title for the entry.
-    title: String,
+    pub title: String,
     /// A universally unique and permanent URI.
-    id: String,
+    pub id: String,
     /// The last time the entry was modified.
-    updated: FixedDateTime,
+    pub updated: FixedDateTime,
     /// The authors of the feed.
-    authors: Vec<Person>,
+    pub authors: Vec<Person>,
     /// The categories that the entry belongs to.
-    categories: Vec<Category>,
+    pub categories: Vec<Category>,
     /// The contributors to the entry.
-    contributors: Vec<Person>,
+    pub contributors: Vec<Person>,
     /// The Web pages related to the entry.
-    links: Vec<Link>,
+    pub links: Vec<Link>,
     /// The time of the initial creation or first availability of the entry.
-    published: Option<FixedDateTime>,
+    pub published: Option<FixedDateTime>,
     /// Information about rights held in and over the entry.
-    rights: Option<String>,
+    pub rights: Option<String>,
     /// The source information if an entry is copied from one feed into another feed.
-    source: Option<Source>,
+    pub source: Option<Source>,
     /// A short summary, abstract, or excerpt of the entry.
-    summary: Option<String>,
+    pub summary: Option<String>,
     /// Contains or links to the complete content of the entry.
-    content: Option<Content>,
+    pub content: Option<Content>,
     /// The extensions for this entry.
-    extensions: ExtensionMap,
+    pub extensions: ExtensionMap,
 }
 
 impl Entry {

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -329,7 +329,7 @@ impl Entry {
     /// assert_eq!(entry.rights(), Some("© 2017 John Doe"));
     /// ```
     pub fn rights(&self) -> Option<&str> {
-        self.rights.as_ref().map(String::as_str)
+        self.rights.as_deref()
     }
 
     /// Set the information about the rights held in and over this entry.
@@ -393,7 +393,7 @@ impl Entry {
     /// assert_eq!(entry.summary(), Some("Entry summary."));
     /// ```
     pub fn summary(&self) -> Option<&str> {
-        self.summary.as_ref().map(String::as_str)
+        self.summary.as_deref()
     }
 
     /// Set the summary of this entry.
@@ -495,7 +495,7 @@ impl Entry {
 }
 
 impl FromXml for Entry {
-    fn from_xml<B: BufRead>(reader: &mut Reader<B>, _: Attributes) -> Result<Self, Error> {
+    fn from_xml<B: BufRead>(reader: &mut Reader<B>, _: Attributes<'_>) -> Result<Self, Error> {
         let mut entry = Entry::default();
         let mut buf = Vec::new();
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,7 +32,7 @@ impl StdError for Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             Error::Xml(ref err) => fmt::Display::fmt(err, f),
             Error::Utf8(ref err) => fmt::Display::fmt(err, f),

--- a/src/extension/mod.rs
+++ b/src/extension/mod.rs
@@ -20,13 +20,13 @@ pub type ExtensionMap = HashMap<String, HashMap<String, Vec<Extension>>>;
 #[cfg_attr(feature = "builders", builder(setter(into), default))]
 pub struct Extension {
     /// The qualified name of the extension element.
-    name: String,
+    pub name: String,
     /// The content of the extension element.
-    value: Option<String>,
+    pub value: Option<String>,
     /// The attributes for the extension element.
-    attrs: HashMap<String, String>,
+    pub attrs: HashMap<String, String>,
     /// The children of the extension element. A map of local names to child elements.
-    children: HashMap<String, Vec<Extension>>,
+    pub children: HashMap<String, Vec<Extension>>,
 }
 
 impl Extension {

--- a/src/extension/mod.rs
+++ b/src/extension/mod.rs
@@ -74,7 +74,7 @@ impl Extension {
     /// assert_eq!(extension.value(), Some("John Doe"));
     /// ```
     pub fn value(&self) -> Option<&str> {
-        self.value.as_ref().map(String::as_str)
+        self.value.as_deref()
     }
 
     /// Set the text content of this extension.

--- a/src/extension/util.rs
+++ b/src/extension/util.rs
@@ -19,7 +19,7 @@ pub fn extension_name(element_name: &[u8]) -> Option<(&[u8], &[u8])> {
 
 pub fn parse_extension<R>(
     reader: &mut Reader<R>,
-    atts: Attributes,
+    atts: Attributes<'_>,
     ns: &[u8],
     name: &[u8],
     extensions: &mut ExtensionMap,
@@ -56,7 +56,7 @@ where
 
 fn parse_extension_element<R: BufRead>(
     reader: &mut Reader<R>,
-    mut atts: Attributes,
+    mut atts: Attributes<'_>,
 ) -> Result<Extension, Error> {
     let mut extension = Extension::default();
     let mut buf = Vec::new();

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -27,35 +27,35 @@ use crate::util::{atom_any_text, atom_datetime, atom_text, default_fixed_datetim
 #[cfg_attr(feature = "builders", builder(setter(into), default))]
 pub struct Feed {
     /// A human-readable title for the feed.
-    title: String,
+    pub title: String,
     /// A universally unique and permanent URI.
-    id: String,
+    pub id: String,
     /// The last time the feed was modified in a significant way.
-    updated: FixedDateTime,
+    pub updated: FixedDateTime,
     /// The authors of the feed.
-    authors: Vec<Person>,
+    pub authors: Vec<Person>,
     /// The categories that the feed belongs to.
-    categories: Vec<Category>,
+    pub categories: Vec<Category>,
     /// The contributors to the feed.
-    contributors: Vec<Person>,
+    pub contributors: Vec<Person>,
     /// The software used to generate the feed.
-    generator: Option<Generator>,
+    pub generator: Option<Generator>,
     /// A small image which provides visual identification for the feed.
-    icon: Option<String>,
+    pub icon: Option<String>,
     /// The Web pages related to the feed.
-    links: Vec<Link>,
+    pub links: Vec<Link>,
     /// A larger image which provides visual identification for the feed.
-    logo: Option<String>,
+    pub logo: Option<String>,
     /// Information about rights held in and over the feed.
-    rights: Option<String>,
+    pub rights: Option<String>,
     /// A human-readable description or subtitle for the feed.
-    subtitle: Option<String>,
+    pub subtitle: Option<String>,
     /// The entries contained in the feed.
-    entries: Vec<Entry>,
+    pub entries: Vec<Entry>,
     /// The extensions for the feed.
-    extensions: ExtensionMap,
+    pub extensions: ExtensionMap,
     /// The namespaces present in the feed tag.
-    namespaces: HashMap<String, String>,
+    pub namespaces: HashMap<String, String>,
 }
 
 impl Feed {

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -370,7 +370,7 @@ impl Feed {
     /// assert_eq!(feed.icon(), Some("http://example.com/icon.png"));
     /// ```
     pub fn icon(&self) -> Option<&str> {
-        self.icon.as_ref().map(String::as_str)
+        self.icon.as_deref()
     }
 
     /// Set the icon for this feed.
@@ -434,7 +434,7 @@ impl Feed {
     /// assert_eq!(feed.logo(), Some("http://example.com/logo.png"));
     /// ```
     pub fn logo(&self) -> Option<&str> {
-        self.logo.as_ref().map(String::as_str)
+        self.logo.as_deref()
     }
 
     /// Set the logo for this feed.
@@ -466,7 +466,7 @@ impl Feed {
     /// assert_eq!(feed.rights(), Some("© 2017 John Doe"));
     /// ```
     pub fn rights(&self) -> Option<&str> {
-        self.rights.as_ref().map(String::as_str)
+        self.rights.as_deref()
     }
 
     /// Set the information about the rights held in and over this feed.
@@ -498,7 +498,7 @@ impl Feed {
     /// assert_eq!(feed.subtitle(), Some("Feed subtitle"));
     /// ```
     pub fn subtitle(&self) -> Option<&str> {
-        self.subtitle.as_ref().map(String::as_str)
+        self.subtitle.as_deref()
     }
 
     /// Set the description or subtitle of this feed.
@@ -636,7 +636,7 @@ impl Feed {
 }
 
 impl FromXml for Feed {
-    fn from_xml<B: BufRead>(reader: &mut Reader<B>, _: Attributes) -> Result<Self, Error> {
+    fn from_xml<B: BufRead>(reader: &mut Reader<B>, _: Attributes<'_>) -> Result<Self, Error> {
         let mut feed = Feed::default();
         let mut buf = Vec::new();
 

--- a/src/fromxml.rs
+++ b/src/fromxml.rs
@@ -6,5 +6,5 @@ use quick_xml::Reader;
 use crate::error::Error;
 
 pub trait FromXml: Sized {
-    fn from_xml<R: BufRead>(reader: &mut Reader<R>, atts: Attributes) -> Result<Self, Error>;
+    fn from_xml<R: BufRead>(reader: &mut Reader<R>, atts: Attributes<'_>) -> Result<Self, Error>;
 }

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -71,7 +71,7 @@ impl Generator {
     /// assert_eq!(generator.uri(), Some("http://example.com/generator"));
     /// ```
     pub fn uri(&self) -> Option<&str> {
-        self.uri.as_ref().map(String::as_str)
+        self.uri.as_deref()
     }
 
     /// Set the URI for the generator.
@@ -103,7 +103,7 @@ impl Generator {
     /// assert_eq!(generator.version(), Some("1.0"));
     /// ```
     pub fn version(&self) -> Option<&str> {
-        self.version.as_ref().map(String::as_str)
+        self.version.as_deref()
     }
 
     /// Set the version of the generator.
@@ -125,7 +125,10 @@ impl Generator {
 }
 
 impl FromXml for Generator {
-    fn from_xml<B: BufRead>(reader: &mut Reader<B>, mut atts: Attributes) -> Result<Self, Error> {
+    fn from_xml<B: BufRead>(
+        reader: &mut Reader<B>,
+        mut atts: Attributes<'_>,
+    ) -> Result<Self, Error> {
         let mut generator = Generator::default();
 
         for attr in atts.with_checks(false) {

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -18,11 +18,11 @@ use crate::util::atom_text;
 #[cfg_attr(feature = "builders", builder(setter(into), default))]
 pub struct Generator {
     /// The name of the generator.
-    value: String,
+    pub value: String,
     /// The generator URI.
-    uri: Option<String>,
+    pub uri: Option<String>,
     /// The generator version.
-    version: Option<String>,
+    pub version: Option<String>,
 }
 
 impl Generator {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![warn(missing_docs)]
+#![warn(missing_docs, rust_2018_idioms)]
 #![doc(html_root_url = "https://docs.rs/atom_syndication/")]
 
 //! Library for serializing the Atom web content syndication format.
@@ -51,10 +51,6 @@ extern crate serde;
 #[cfg(feature = "builders")]
 #[macro_use]
 extern crate derive_builder;
-
-extern crate quick_xml;
-
-extern crate chrono;
 
 mod category;
 mod content;

--- a/src/link.rs
+++ b/src/link.rs
@@ -120,7 +120,7 @@ impl Link {
     /// assert_eq!(link.hreflang(), Some("en"));
     /// ```
     pub fn hreflang(&self) -> Option<&str> {
-        self.hreflang.as_ref().map(String::as_str)
+        self.hreflang.as_deref()
     }
 
     /// Set the language of the referenced resource.
@@ -152,7 +152,7 @@ impl Link {
     /// assert_eq!(link.mime_type(), Some("text/html"));
     /// ```
     pub fn mime_type(&self) -> Option<&str> {
-        self.mime_type.as_ref().map(String::as_str)
+        self.mime_type.as_deref()
     }
 
     /// Set the MIME type of the referenced resource.
@@ -184,7 +184,7 @@ impl Link {
     /// assert_eq!(link.title(), Some("Article Title"));
     /// ```
     pub fn title(&self) -> Option<&str> {
-        self.title.as_ref().map(String::as_str)
+        self.title.as_deref()
     }
 
     /// Set the title of the referenced resource.
@@ -216,7 +216,7 @@ impl Link {
     /// assert_eq!(link.length(), Some("1000"));
     /// ```
     pub fn length(&self) -> Option<&str> {
-        self.length.as_ref().map(String::as_str)
+        self.length.as_deref()
     }
 
     /// Set the content length of the referenced resource in bytes.
@@ -238,7 +238,10 @@ impl Link {
 }
 
 impl FromXml for Link {
-    fn from_xml<B: BufRead>(reader: &mut Reader<B>, mut atts: Attributes) -> Result<Self, Error> {
+    fn from_xml<B: BufRead>(
+        reader: &mut Reader<B>,
+        mut atts: Attributes<'_>,
+    ) -> Result<Self, Error> {
         let mut link = Link::default();
 
         for attr in atts.with_checks(false) {

--- a/src/link.rs
+++ b/src/link.rs
@@ -17,17 +17,17 @@ use crate::toxml::ToXml;
 #[cfg_attr(feature = "builders", builder(setter(into), default))]
 pub struct Link {
     /// The URI of the referenced resource.
-    href: String,
+    pub href: String,
     /// The link relationship type.
-    rel: String,
+    pub rel: String,
     /// The language of the resource.
-    hreflang: Option<String>,
+    pub hreflang: Option<String>,
     /// The MIME type of the resource.
-    mime_type: Option<String>,
+    pub mime_type: Option<String>,
     /// Human-readable information about the link.
-    title: Option<String>,
+    pub title: Option<String>,
     /// The length of the resource, in bytes.
-    length: Option<String>,
+    pub length: Option<String>,
 }
 
 impl Default for Link {

--- a/src/person.rs
+++ b/src/person.rs
@@ -18,11 +18,11 @@ use crate::util::atom_text;
 #[cfg_attr(feature = "builders", builder(setter(into), default))]
 pub struct Person {
     /// A human-readable name for the person.
-    name: String,
+    pub name: String,
     /// An email address for the person.
-    email: Option<String>,
+    pub email: Option<String>,
     /// A Web page for the person.
-    uri: Option<String>,
+    pub uri: Option<String>,
 }
 
 impl Person {

--- a/src/person.rs
+++ b/src/person.rs
@@ -70,7 +70,7 @@ impl Person {
     /// assert_eq!(person.email(), Some("johndoe@example.com"));
     /// ```
     pub fn email(&self) -> Option<&str> {
-        self.email.as_ref().map(String::as_str)
+        self.email.as_deref()
     }
 
     /// Set the email address for this person.
@@ -102,7 +102,7 @@ impl Person {
     /// assert_eq!(person.uri(), Some("http://example.com"));
     /// ```
     pub fn uri(&self) -> Option<&str> {
-        self.uri.as_ref().map(String::as_str)
+        self.uri.as_deref()
     }
 
     /// Set the Web page for this person.
@@ -124,7 +124,7 @@ impl Person {
 }
 
 impl FromXml for Person {
-    fn from_xml<B: BufRead>(reader: &mut Reader<B>, _: Attributes) -> Result<Self, Error> {
+    fn from_xml<B: BufRead>(reader: &mut Reader<B>, _: Attributes<'_>) -> Result<Self, Error> {
         let mut person = Person::default();
         let mut buf = Vec::new();
 

--- a/src/source.rs
+++ b/src/source.rs
@@ -22,29 +22,29 @@ use crate::util::{atom_datetime, atom_text, default_fixed_datetime, FixedDateTim
 #[cfg_attr(feature = "builders", builder(setter(into), default))]
 pub struct Source {
     /// A human-readable title for the feed.
-    title: String,
+    pub title: String,
     /// A universally unique and permanent URI.
-    id: String,
+    pub id: String,
     /// The last time the feed was modified in a significant way.
-    updated: FixedDateTime,
+    pub updated: FixedDateTime,
     /// The authors of the feed.
-    authors: Vec<Person>,
+    pub authors: Vec<Person>,
     /// The categories that the feed belongs to.
-    categories: Vec<Category>,
+    pub categories: Vec<Category>,
     /// The contributors to the feed.
-    contributors: Vec<Person>,
+    pub contributors: Vec<Person>,
     /// The software used to generate the feed.
-    generator: Option<Generator>,
+    pub generator: Option<Generator>,
     /// A small image which provides visual identification for the feed.
-    icon: Option<String>,
+    pub icon: Option<String>,
     /// The Web pages related to the feed.
-    links: Vec<Link>,
+    pub links: Vec<Link>,
     /// A larger image which provides visual identification for the feed.
-    logo: Option<String>,
+    pub logo: Option<String>,
     /// Information about rights held in and over the feed.
-    rights: Option<String>,
+    pub rights: Option<String>,
     /// A human-readable description or subtitle for the feed.
-    subtitle: Option<String>,
+    pub subtitle: Option<String>,
 }
 
 impl Source {

--- a/src/source.rs
+++ b/src/source.rs
@@ -288,7 +288,7 @@ impl Source {
     /// assert_eq!(source.icon(), Some("http://example.com/icon.png"));
     /// ```
     pub fn icon(&self) -> Option<&str> {
-        self.icon.as_ref().map(String::as_str)
+        self.icon.as_deref()
     }
 
     /// Set the icon for the source feed.
@@ -352,7 +352,7 @@ impl Source {
     /// assert_eq!(source.logo(), Some("http://example.com/logo.png"));
     /// ```
     pub fn logo(&self) -> Option<&str> {
-        self.logo.as_ref().map(String::as_str)
+        self.logo.as_deref()
     }
 
     /// Set the logo for the source feed.
@@ -384,7 +384,7 @@ impl Source {
     /// assert_eq!(source.rights(), Some("© 2017 John Doe"));
     /// ```
     pub fn rights(&self) -> Option<&str> {
-        self.rights.as_ref().map(String::as_str)
+        self.rights.as_deref()
     }
 
     /// Set the information about the rights held in and over the source feed.
@@ -416,7 +416,7 @@ impl Source {
     /// assert_eq!(source.subtitle(), Some("Feed subtitle"));
     /// ```
     pub fn subtitle(&self) -> Option<&str> {
-        self.subtitle.as_ref().map(String::as_str)
+        self.subtitle.as_deref()
     }
 
     /// Set the description or subtitle of the source feed.
@@ -438,7 +438,7 @@ impl Source {
 }
 
 impl FromXml for Source {
-    fn from_xml<B: BufRead>(reader: &mut Reader<B>, _: Attributes) -> Result<Self, Error> {
+    fn from_xml<B: BufRead>(reader: &mut Reader<B>, _: Attributes<'_>) -> Result<Self, Error> {
         let mut source = Source::default();
         let mut buf = Vec::new();
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -132,7 +132,7 @@ pub fn atom_xhtml<B: BufRead>(reader: &mut Reader<B>) -> Result<Option<String>, 
 
 pub fn atom_any_text<B: BufRead>(
     reader: &mut Reader<B>,
-    mut atts: Attributes,
+    mut atts: Attributes<'_>,
 ) -> Result<Option<String>, Error> {
     let mut content_type = None;
     for attr in atts.with_checks(false) {


### PR DESCRIPTION
This makes all fields (attributes, child elements and extensions/namespaces) public, as discussed in #24.

As a side effect, the change makes any addition of fields in a future version a breaking change ([Rust RFC 1105]). This could be prevented by the [`#[non_exhaustive]`][non_exhaustive] attribute or by adding a dummy private field, but that would prevent the library users from using the functional record update syntax (`let new = Feed { title: "foo".into(), ..old };`).

[Rust RFC 1105]: https://rust-lang.github.io/rfcs/1105-api-evolution.html#structs
[non_exhaustive]: https://github.com/rust-lang/rust/blob/dbfb00c4de2bd2c071344729dd3609a963b2da4c/RELEASES.md#language

After this change, direct access to the fields might become preferable to the getter and setter methods (like `Feed::title` and `set_title`), but removing them would be a breaking change and is out of scope of this pull request.

Closes #24.