### PR TITLE
Wrapped quick_xml::error in a new type to hide quick_xml

### DIFF
--- a/src/category.rs
+++ b/src/category.rs
@@ -181,7 +181,9 @@ impl ToXml for Category {
             element.push_attribute(("label", &**label));
         }
 
-        writer.write_event(Event::Empty(element)).map_err(XmlError::new)?;
+        writer
+            .write_event(Event::Empty(element))
+            .map_err(XmlError::new)?;
 
         Ok(())
     }

--- a/src/category.rs
+++ b/src/category.rs
@@ -168,7 +168,7 @@ impl FromXml for Category {
 }
 
 impl ToXml for Category {
-    fn to_xml<W: Write>(&self, writer: &mut Writer<W>) -> Result<(), quick_xml::Error> {
+    fn to_xml<W: Write>(&self, writer: &mut Writer<W>) -> Result<(), XmlError> {
         let name = b"category";
         let mut element = BytesStart::borrowed(name, name.len());
         element.push_attribute(("term", &*self.term));
@@ -181,7 +181,7 @@ impl ToXml for Category {
             element.push_attribute(("label", &**label));
         }
 
-        writer.write_event(Event::Empty(element))?;
+        writer.write_event(Event::Empty(element)).map_err(XmlError::new)?;
 
         Ok(())
     }

--- a/src/content.rs
+++ b/src/content.rs
@@ -236,19 +236,25 @@ impl ToXml for Content {
             element.push_attribute(("src", &**src));
         }
 
-        writer.write_event(Event::Start(element)).map_err(XmlError::new)?;
+        writer
+            .write_event(Event::Start(element))
+            .map_err(XmlError::new)?;
 
         if let Some(ref value) = self.value {
-            writer.write_event(Event::Text(
-                if self.content_type.as_deref() == Some("xhtml") {
-                    BytesText::from_escaped(value.as_bytes())
-                } else {
-                    BytesText::from_plain(value.as_bytes())
-                },
-            )).map_err(XmlError::new)?;
+            writer
+                .write_event(Event::Text(
+                    if self.content_type.as_deref() == Some("xhtml") {
+                        BytesText::from_escaped(value.as_bytes())
+                    } else {
+                        BytesText::from_plain(value.as_bytes())
+                    },
+                ))
+                .map_err(XmlError::new)?;
         }
 
-        writer.write_event(Event::End(BytesEnd::borrowed(name))).map_err(XmlError::new)?;
+        writer
+            .write_event(Event::End(BytesEnd::borrowed(name)))
+            .map_err(XmlError::new)?;
 
         Ok(())
     }

--- a/src/content.rs
+++ b/src/content.rs
@@ -212,7 +212,7 @@ impl FromXml for Content {
 }
 
 impl ToXml for Content {
-    fn to_xml<W: Write>(&self, writer: &mut Writer<W>) -> Result<(), quick_xml::Error> {
+    fn to_xml<W: Write>(&self, writer: &mut Writer<W>) -> Result<(), XmlError> {
         let name = b"content";
         let mut element = BytesStart::borrowed(name, name.len());
 
@@ -236,7 +236,7 @@ impl ToXml for Content {
             element.push_attribute(("src", &**src));
         }
 
-        writer.write_event(Event::Start(element))?;
+        writer.write_event(Event::Start(element)).map_err(XmlError::new)?;
 
         if let Some(ref value) = self.value {
             writer.write_event(Event::Text(
@@ -245,10 +245,10 @@ impl ToXml for Content {
                 } else {
                     BytesText::from_plain(value.as_bytes())
                 },
-            ))?;
+            )).map_err(XmlError::new)?;
         }
 
-        writer.write_event(Event::End(BytesEnd::borrowed(name)))?;
+        writer.write_event(Event::End(BytesEnd::borrowed(name))).map_err(XmlError::new)?;
 
         Ok(())
     }

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -572,9 +572,9 @@ impl FromXml for Entry {
 }
 
 impl ToXml for Entry {
-    fn to_xml<W: Write>(&self, writer: &mut Writer<W>) -> Result<(), quick_xml::Error> {
+    fn to_xml<W: Write>(&self, writer: &mut Writer<W>) -> Result<(), XmlError> {
         let name = b"entry";
-        writer.write_event(Event::Start(BytesStart::borrowed(name, name.len())))?;
+        writer.write_event(Event::Start(BytesStart::borrowed(name, name.len()))).map_err(XmlError::new)?;
         writer.write_object_named(&self.title, b"title")?;
         writer.write_text_element(b"id", &*self.id)?;
         writer.write_text_element(b"updated", &*self.updated.to_rfc3339())?;
@@ -609,7 +609,7 @@ impl ToXml for Entry {
             }
         }
 
-        writer.write_event(Event::End(BytesEnd::borrowed(name)))?;
+        writer.write_event(Event::End(BytesEnd::borrowed(name))).map_err(XmlError::new)?;
 
         Ok(())
     }

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -574,7 +574,9 @@ impl FromXml for Entry {
 impl ToXml for Entry {
     fn to_xml<W: Write>(&self, writer: &mut Writer<W>) -> Result<(), XmlError> {
         let name = b"entry";
-        writer.write_event(Event::Start(BytesStart::borrowed(name, name.len()))).map_err(XmlError::new)?;
+        writer
+            .write_event(Event::Start(BytesStart::borrowed(name, name.len())))
+            .map_err(XmlError::new)?;
         writer.write_object_named(&self.title, b"title")?;
         writer.write_text_element(b"id", &*self.id)?;
         writer.write_text_element(b"updated", &*self.updated.to_rfc3339())?;
@@ -609,7 +611,9 @@ impl ToXml for Entry {
             }
         }
 
-        writer.write_event(Event::End(BytesEnd::borrowed(name))).map_err(XmlError::new)?;
+        writer
+            .write_event(Event::End(BytesEnd::borrowed(name)))
+            .map_err(XmlError::new)?;
 
         Ok(())
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,8 +2,6 @@ use std::error::Error as StdError;
 use std::fmt;
 use std::str::Utf8Error;
 
-use quick_xml::Error as XmlError;
-
 #[derive(Debug)]
 /// An error that occurred while performing an Atom operation.
 #[non_exhaustive]
@@ -30,7 +28,7 @@ pub enum Error {
 impl StdError for Error {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match *self {
-            Error::Xml(ref err) => Some(err),
+            Error::Xml(XmlError(ref err)) => Some(err),
             Error::Utf8(ref err) => Some(err),
             Error::InvalidStartTag => None,
             Error::Eof => None,
@@ -43,7 +41,7 @@ impl StdError for Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            Error::Xml(ref err) => fmt::Display::fmt(err, f),
+            Error::Xml(XmlError(ref err)) => fmt::Display::fmt(err, f),
             Error::Utf8(ref err) => fmt::Display::fmt(err, f),
             Error::InvalidStartTag => write!(f, "input did not begin with an opening feed tag"),
             Error::Eof => write!(f, "unexpected end of input"),
@@ -73,5 +71,14 @@ impl From<XmlError> for Error {
 impl From<Utf8Error> for Error {
     fn from(err: Utf8Error) -> Error {
         Error::Utf8(err)
+    }
+}
+
+#[derive(Debug)]
+pub struct XmlError(quick_xml::Error);
+
+impl XmlError {
+    pub(crate) fn new(err: quick_xml::Error) -> Self {
+        Self(err)
     }
 }

--- a/src/extension/mod.rs
+++ b/src/extension/mod.rs
@@ -3,9 +3,9 @@ use std::io::Write;
 use std::str;
 
 use quick_xml::events::{BytesEnd, BytesStart, BytesText, Event};
-use quick_xml::Error as XmlError;
 use quick_xml::Writer;
 
+use crate::error::XmlError;
 use crate::toxml::ToXml;
 
 pub(crate) mod util;
@@ -185,17 +185,17 @@ impl ToXml for Extension {
         let name = self.name.as_bytes();
         let mut element = BytesStart::borrowed(name, name.len());
         element.extend_attributes(self.attrs.iter().map(|a| (a.0.as_bytes(), a.1.as_bytes())));
-        writer.write_event(Event::Start(element))?;
+        writer.write_event(Event::Start(element)).map_err(XmlError::new)?;
 
         if let Some(value) = self.value.as_ref() {
-            writer.write_event(Event::Text(BytesText::from_escaped(value.as_bytes())))?;
+            writer.write_event(Event::Text(BytesText::from_escaped(value.as_bytes()))).map_err(XmlError::new)?;
         }
 
         for extension in self.children.values().flatten() {
             extension.to_xml(writer)?;
         }
 
-        writer.write_event(Event::End(BytesEnd::borrowed(name)))?;
+        writer.write_event(Event::End(BytesEnd::borrowed(name))).map_err(XmlError::new)?;
         Ok(())
     }
 }

--- a/src/extension/mod.rs
+++ b/src/extension/mod.rs
@@ -185,17 +185,23 @@ impl ToXml for Extension {
         let name = self.name.as_bytes();
         let mut element = BytesStart::borrowed(name, name.len());
         element.extend_attributes(self.attrs.iter().map(|a| (a.0.as_bytes(), a.1.as_bytes())));
-        writer.write_event(Event::Start(element)).map_err(XmlError::new)?;
+        writer
+            .write_event(Event::Start(element))
+            .map_err(XmlError::new)?;
 
         if let Some(value) = self.value.as_ref() {
-            writer.write_event(Event::Text(BytesText::from_escaped(value.as_bytes()))).map_err(XmlError::new)?;
+            writer
+                .write_event(Event::Text(BytesText::from_escaped(value.as_bytes())))
+                .map_err(XmlError::new)?;
         }
 
         for extension in self.children.values().flatten() {
             extension.to_xml(writer)?;
         }
 
-        writer.write_event(Event::End(BytesEnd::borrowed(name))).map_err(XmlError::new)?;
+        writer
+            .write_event(Event::End(BytesEnd::borrowed(name)))
+            .map_err(XmlError::new)?;
         Ok(())
     }
 }

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -137,7 +137,7 @@ impl Feed {
         writer
             .write_event(Event::Text(BytesText::from_escaped("\n".as_bytes())))
             .map_err(XmlError::new)?;
-        self.to_xml(&mut writer).map_err(XmlError::new)?;
+        self.to_xml(&mut writer)?;
         Ok(writer.into_inner())
     }
 
@@ -767,7 +767,7 @@ impl FromXml for Feed {
 }
 
 impl ToXml for Feed {
-    fn to_xml<W: Write>(&self, writer: &mut Writer<W>) -> Result<(), quick_xml::Error> {
+    fn to_xml<W: Write>(&self, writer: &mut Writer<W>) -> Result<(),XmlError> {
         let name = b"feed";
         let mut element = BytesStart::borrowed(name, name.len());
         element.push_attribute(("xmlns", "http://www.w3.org/2005/Atom"));
@@ -784,7 +784,7 @@ impl ToXml for Feed {
             element.push_attribute(("xml:lang", lang.as_str()));
         }
 
-        writer.write_event(Event::Start(element))?;
+        writer.write_event(Event::Start(element)).map_err(XmlError::new)?;
         writer.write_object_named(&self.title, b"title")?;
         writer.write_text_element(b"id", &*self.id)?;
         writer.write_text_element(b"updated", &*self.updated.to_rfc3339())?;
@@ -822,7 +822,7 @@ impl ToXml for Feed {
             }
         }
 
-        writer.write_event(Event::End(BytesEnd::borrowed(name)))?;
+        writer.write_event(Event::End(BytesEnd::borrowed(name))).map_err(XmlError::new)?;
 
         Ok(())
     }

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -767,7 +767,7 @@ impl FromXml for Feed {
 }
 
 impl ToXml for Feed {
-    fn to_xml<W: Write>(&self, writer: &mut Writer<W>) -> Result<(),XmlError> {
+    fn to_xml<W: Write>(&self, writer: &mut Writer<W>) -> Result<(), XmlError> {
         let name = b"feed";
         let mut element = BytesStart::borrowed(name, name.len());
         element.push_attribute(("xmlns", "http://www.w3.org/2005/Atom"));
@@ -784,7 +784,9 @@ impl ToXml for Feed {
             element.push_attribute(("xml:lang", lang.as_str()));
         }
 
-        writer.write_event(Event::Start(element)).map_err(XmlError::new)?;
+        writer
+            .write_event(Event::Start(element))
+            .map_err(XmlError::new)?;
         writer.write_object_named(&self.title, b"title")?;
         writer.write_text_element(b"id", &*self.id)?;
         writer.write_text_element(b"updated", &*self.updated.to_rfc3339())?;
@@ -822,7 +824,9 @@ impl ToXml for Feed {
             }
         }
 
-        writer.write_event(Event::End(BytesEnd::borrowed(name))).map_err(XmlError::new)?;
+        writer
+            .write_event(Event::End(BytesEnd::borrowed(name)))
+            .map_err(XmlError::new)?;
 
         Ok(())
     }

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -2,11 +2,10 @@ use std::io::{BufRead, Write};
 
 use quick_xml::events::attributes::Attributes;
 use quick_xml::events::{BytesEnd, BytesStart, BytesText, Event};
-use quick_xml::Error as XmlError;
 use quick_xml::Reader;
 use quick_xml::Writer;
 
-use crate::error::Error;
+use crate::error::{Error, XmlError};
 use crate::fromxml::FromXml;
 use crate::toxml::ToXml;
 use crate::util::atom_text;
@@ -140,8 +139,18 @@ impl FromXml for Generator {
 
         for att in atts.with_checks(false).flatten() {
             match att.key {
-                b"uri" => generator.uri = Some(att.unescape_and_decode_value(reader)?),
-                b"version" => generator.version = Some(att.unescape_and_decode_value(reader)?),
+                b"uri" => {
+                    generator.uri = Some(
+                        att.unescape_and_decode_value(reader)
+                            .map_err(XmlError::new)?,
+                    )
+                }
+                b"version" => {
+                    generator.version = Some(
+                        att.unescape_and_decode_value(reader)
+                            .map_err(XmlError::new)?,
+                    )
+                }
                 _ => {}
             }
         }
@@ -153,7 +162,7 @@ impl FromXml for Generator {
 }
 
 impl ToXml for Generator {
-    fn to_xml<W: Write>(&self, writer: &mut Writer<W>) -> Result<(), XmlError> {
+    fn to_xml<W: Write>(&self, writer: &mut Writer<W>) -> Result<(), quick_xml::Error> {
         let name = b"generator";
         let mut element = BytesStart::borrowed(name, name.len());
 

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -162,7 +162,7 @@ impl FromXml for Generator {
 }
 
 impl ToXml for Generator {
-    fn to_xml<W: Write>(&self, writer: &mut Writer<W>) -> Result<(), quick_xml::Error> {
+    fn to_xml<W: Write>(&self, writer: &mut Writer<W>) -> Result<(), XmlError> {
         let name = b"generator";
         let mut element = BytesStart::borrowed(name, name.len());
 
@@ -174,9 +174,9 @@ impl ToXml for Generator {
             element.push_attribute(("version", &**version));
         }
 
-        writer.write_event(Event::Start(element))?;
-        writer.write_event(Event::Text(BytesText::from_escaped(self.value.as_bytes())))?;
-        writer.write_event(Event::End(BytesEnd::borrowed(name)))?;
+        writer.write_event(Event::Start(element)).map_err(XmlError::new)?;
+        writer.write_event(Event::Text(BytesText::from_escaped(self.value.as_bytes()))).map_err(XmlError::new)?;
+        writer.write_event(Event::End(BytesEnd::borrowed(name))).map_err(XmlError::new)?;
 
         Ok(())
     }

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -174,9 +174,15 @@ impl ToXml for Generator {
             element.push_attribute(("version", &**version));
         }
 
-        writer.write_event(Event::Start(element)).map_err(XmlError::new)?;
-        writer.write_event(Event::Text(BytesText::from_escaped(self.value.as_bytes()))).map_err(XmlError::new)?;
-        writer.write_event(Event::End(BytesEnd::borrowed(name))).map_err(XmlError::new)?;
+        writer
+            .write_event(Event::Start(element))
+            .map_err(XmlError::new)?;
+        writer
+            .write_event(Event::Text(BytesText::from_escaped(self.value.as_bytes())))
+            .map_err(XmlError::new)?;
+        writer
+            .write_event(Event::End(BytesEnd::borrowed(name)))
+            .map_err(XmlError::new)?;
 
         Ok(())
     }

--- a/src/link.rs
+++ b/src/link.rs
@@ -274,7 +274,7 @@ impl FromXml for Link {
 }
 
 impl ToXml for Link {
-    fn to_xml<W: Write>(&self, writer: &mut Writer<W>) -> Result<(), quick_xml::Error> {
+    fn to_xml<W: Write>(&self, writer: &mut Writer<W>) -> Result<(), XmlError> {
         let name = b"link";
         let mut element = BytesStart::borrowed(name, name.len());
         element.push_attribute(("href", &*self.href));
@@ -296,7 +296,7 @@ impl ToXml for Link {
             element.push_attribute(("length", &**length));
         }
 
-        writer.write_event(Event::Empty(element))?;
+        writer.write_event(Event::Empty(element)).map_err(XmlError::new)?;
 
         Ok(())
     }

--- a/src/link.rs
+++ b/src/link.rs
@@ -2,11 +2,10 @@ use std::io::{BufRead, Write};
 
 use quick_xml::events::attributes::Attributes;
 use quick_xml::events::{BytesStart, Event};
-use quick_xml::Error as XmlError;
 use quick_xml::Reader;
 use quick_xml::Writer;
 
-use crate::error::Error;
+use crate::error::{Error, XmlError};
 use crate::fromxml::FromXml;
 use crate::toxml::ToXml;
 
@@ -245,32 +244,37 @@ impl Link {
 }
 
 impl FromXml for Link {
-    fn from_xml<B: BufRead>(
-        reader: &mut Reader<B>,
-        mut atts: Attributes<'_>,
-    ) -> Result<Self, Error> {
-        let mut link = Link::default();
+    fn from_xml<B: BufRead>(reader: &mut Reader<B>, atts: Attributes<'_>) -> Result<Self, Error> {
+        fn from_xml_inner<B: BufRead>(
+            reader: &mut Reader<B>,
+            mut atts: Attributes<'_>,
+        ) -> Result<Link, quick_xml::Error> {
+            let mut link = Link::default();
 
-        for att in atts.with_checks(false).flatten() {
-            match att.key {
-                b"href" => link.href = att.unescape_and_decode_value(reader)?,
-                b"rel" => link.rel = att.unescape_and_decode_value(reader)?,
-                b"hreflang" => link.hreflang = Some(att.unescape_and_decode_value(reader)?),
-                b"type" => link.mime_type = Some(att.unescape_and_decode_value(reader)?),
-                b"title" => link.title = Some(att.unescape_and_decode_value(reader)?),
-                b"length" => link.length = Some(att.unescape_and_decode_value(reader)?),
-                _ => {}
+            for att in atts.with_checks(false).flatten() {
+                match att.key {
+                    b"href" => link.href = att.unescape_and_decode_value(reader)?,
+                    b"rel" => link.rel = att.unescape_and_decode_value(reader)?,
+                    b"hreflang" => link.hreflang = Some(att.unescape_and_decode_value(reader)?),
+                    b"type" => link.mime_type = Some(att.unescape_and_decode_value(reader)?),
+                    b"title" => link.title = Some(att.unescape_and_decode_value(reader)?),
+                    b"length" => link.length = Some(att.unescape_and_decode_value(reader)?),
+                    _ => {}
+                }
             }
+
+            reader.read_to_end(b"link", &mut Vec::new())?;
+
+            Ok(link)
         }
-
-        reader.read_to_end(b"link", &mut Vec::new())?;
-
-        Ok(link)
+        from_xml_inner(reader, atts)
+            .map_err(XmlError::new)
+            .map_err(Error::from)
     }
 }
 
 impl ToXml for Link {
-    fn to_xml<W: Write>(&self, writer: &mut Writer<W>) -> Result<(), XmlError> {
+    fn to_xml<W: Write>(&self, writer: &mut Writer<W>) -> Result<(), quick_xml::Error> {
         let name = b"link";
         let mut element = BytesStart::borrowed(name, name.len());
         element.push_attribute(("href", &*self.href));

--- a/src/link.rs
+++ b/src/link.rs
@@ -296,7 +296,9 @@ impl ToXml for Link {
             element.push_attribute(("length", &**length));
         }
 
-        writer.write_event(Event::Empty(element)).map_err(XmlError::new)?;
+        writer
+            .write_event(Event::Empty(element))
+            .map_err(XmlError::new)?;
 
         Ok(())
     }

--- a/src/person.rs
+++ b/src/person.rs
@@ -157,13 +157,13 @@ impl FromXml for Person {
 }
 
 impl ToXmlNamed for Person {
-    fn to_xml_named<W, N>(&self, writer: &mut Writer<W>, name: N) -> Result<(), quick_xml::Error>
+    fn to_xml_named<W, N>(&self, writer: &mut Writer<W>, name: N) -> Result<(), XmlError>
     where
         W: Write,
         N: AsRef<[u8]>,
     {
         let name = name.as_ref();
-        writer.write_event(Event::Start(BytesStart::borrowed(name, name.len())))?;
+        writer.write_event(Event::Start(BytesStart::borrowed(name, name.len()))).map_err(XmlError::new)?;
         writer.write_text_element(b"name", &*self.name)?;
 
         if let Some(ref email) = self.email {
@@ -174,7 +174,7 @@ impl ToXmlNamed for Person {
             writer.write_text_element(b"uri", &*uri)?;
         }
 
-        writer.write_event(Event::End(BytesEnd::borrowed(name)))?;
+        writer.write_event(Event::End(BytesEnd::borrowed(name))).map_err(XmlError::new)?;
 
         Ok(())
     }

--- a/src/person.rs
+++ b/src/person.rs
@@ -163,7 +163,9 @@ impl ToXmlNamed for Person {
         N: AsRef<[u8]>,
     {
         let name = name.as_ref();
-        writer.write_event(Event::Start(BytesStart::borrowed(name, name.len()))).map_err(XmlError::new)?;
+        writer
+            .write_event(Event::Start(BytesStart::borrowed(name, name.len())))
+            .map_err(XmlError::new)?;
         writer.write_text_element(b"name", &*self.name)?;
 
         if let Some(ref email) = self.email {
@@ -174,7 +176,9 @@ impl ToXmlNamed for Person {
             writer.write_text_element(b"uri", &*uri)?;
         }
 
-        writer.write_event(Event::End(BytesEnd::borrowed(name))).map_err(XmlError::new)?;
+        writer
+            .write_event(Event::End(BytesEnd::borrowed(name)))
+            .map_err(XmlError::new)?;
 
         Ok(())
     }

--- a/src/source.rs
+++ b/src/source.rs
@@ -502,9 +502,9 @@ impl FromXml for Source {
 }
 
 impl ToXml for Source {
-    fn to_xml<W: Write>(&self, writer: &mut Writer<W>) -> Result<(), quick_xml::Error> {
+    fn to_xml<W: Write>(&self, writer: &mut Writer<W>) -> Result<(), XmlError> {
         let name = b"source";
-        writer.write_event(Event::Start(BytesStart::borrowed(name, name.len())))?;
+        writer.write_event(Event::Start(BytesStart::borrowed(name, name.len()))).map_err(XmlError::new)?;
         writer.write_object_named(&self.title, b"title")?;
         writer.write_text_element(b"id", &*self.id)?;
         writer.write_text_element(b"updated", &self.updated.to_rfc3339())?;
@@ -534,7 +534,7 @@ impl ToXml for Source {
             writer.write_object_named(subtitle, b"subtitle")?;
         }
 
-        writer.write_event(Event::End(BytesEnd::borrowed(name)))?;
+        writer.write_event(Event::End(BytesEnd::borrowed(name))).map_err(XmlError::new)?;
 
         Ok(())
     }

--- a/src/source.rs
+++ b/src/source.rs
@@ -504,7 +504,9 @@ impl FromXml for Source {
 impl ToXml for Source {
     fn to_xml<W: Write>(&self, writer: &mut Writer<W>) -> Result<(), XmlError> {
         let name = b"source";
-        writer.write_event(Event::Start(BytesStart::borrowed(name, name.len()))).map_err(XmlError::new)?;
+        writer
+            .write_event(Event::Start(BytesStart::borrowed(name, name.len())))
+            .map_err(XmlError::new)?;
         writer.write_object_named(&self.title, b"title")?;
         writer.write_text_element(b"id", &*self.id)?;
         writer.write_text_element(b"updated", &self.updated.to_rfc3339())?;
@@ -534,7 +536,9 @@ impl ToXml for Source {
             writer.write_object_named(subtitle, b"subtitle")?;
         }
 
-        writer.write_event(Event::End(BytesEnd::borrowed(name))).map_err(XmlError::new)?;
+        writer
+            .write_event(Event::End(BytesEnd::borrowed(name)))
+            .map_err(XmlError::new)?;
 
         Ok(())
     }

--- a/src/text.rs
+++ b/src/text.rs
@@ -214,13 +214,21 @@ impl ToXmlNamed for Text {
         if self.r#type != TextType::default() {
             element.push_attribute(("type", self.r#type.as_str()));
         }
-        writer.write_event(Event::Start(element)).map_err(XmlError::new)?;
+        writer
+            .write_event(Event::Start(element))
+            .map_err(XmlError::new)?;
         if self.r#type == TextType::Xhtml {
-            writer.write_event(Event::Text(BytesText::from_escaped(self.value.as_bytes()))).map_err(XmlError::new)?;
+            writer
+                .write_event(Event::Text(BytesText::from_escaped(self.value.as_bytes())))
+                .map_err(XmlError::new)?;
         } else {
-            writer.write_event(Event::Text(BytesText::from_plain_str(self.value.as_str()))).map_err(XmlError::new)?;
+            writer
+                .write_event(Event::Text(BytesText::from_plain_str(self.value.as_str())))
+                .map_err(XmlError::new)?;
         }
-        writer.write_event(Event::End(BytesEnd::borrowed(name))).map_err(XmlError::new)?;
+        writer
+            .write_event(Event::End(BytesEnd::borrowed(name)))
+            .map_err(XmlError::new)?;
 
         Ok(())
     }

--- a/src/text.rs
+++ b/src/text.rs
@@ -198,7 +198,7 @@ impl FromXml for Text {
 }
 
 impl ToXmlNamed for Text {
-    fn to_xml_named<W, N>(&self, writer: &mut Writer<W>, name: N) -> Result<(), quick_xml::Error>
+    fn to_xml_named<W, N>(&self, writer: &mut Writer<W>, name: N) -> Result<(), XmlError>
     where
         W: Write,
         N: AsRef<[u8]>,
@@ -214,13 +214,13 @@ impl ToXmlNamed for Text {
         if self.r#type != TextType::default() {
             element.push_attribute(("type", self.r#type.as_str()));
         }
-        writer.write_event(Event::Start(element))?;
+        writer.write_event(Event::Start(element)).map_err(XmlError::new)?;
         if self.r#type == TextType::Xhtml {
-            writer.write_event(Event::Text(BytesText::from_escaped(self.value.as_bytes())))?;
+            writer.write_event(Event::Text(BytesText::from_escaped(self.value.as_bytes()))).map_err(XmlError::new)?;
         } else {
-            writer.write_event(Event::Text(BytesText::from_plain_str(self.value.as_str())))?;
+            writer.write_event(Event::Text(BytesText::from_plain_str(self.value.as_str()))).map_err(XmlError::new)?;
         }
-        writer.write_event(Event::End(BytesEnd::borrowed(name)))?;
+        writer.write_event(Event::End(BytesEnd::borrowed(name))).map_err(XmlError::new)?;
 
         Ok(())
     }

--- a/src/toxml.rs
+++ b/src/toxml.rs
@@ -72,9 +72,12 @@ impl<W: Write> WriterExt for Writer<W> {
         T: AsRef<[u8]>,
     {
         let name = name.as_ref();
-        self.write_event(Event::Start(BytesStart::borrowed(name, name.len()))).map_err(XmlError::new)?;
-        self.write_event(Event::Text(BytesText::from_escaped(text.as_ref()))).map_err(XmlError::new)?;
-        self.write_event(Event::End(BytesEnd::borrowed(name))).map_err(XmlError::new)?;
+        self.write_event(Event::Start(BytesStart::borrowed(name, name.len())))
+            .map_err(XmlError::new)?;
+        self.write_event(Event::Text(BytesText::from_escaped(text.as_ref())))
+            .map_err(XmlError::new)?;
+        self.write_event(Event::End(BytesEnd::borrowed(name)))
+            .map_err(XmlError::new)?;
         Ok(())
     }
 

--- a/src/toxml.rs
+++ b/src/toxml.rs
@@ -1,8 +1,9 @@
 use std::io::Write;
 
 use quick_xml::events::{BytesEnd, BytesStart, BytesText, Event};
-use quick_xml::Error as XmlError;
 use quick_xml::Writer;
+
+use crate::error::XmlError;
 
 pub trait ToXml {
     fn to_xml<W: Write>(&self, writer: &mut Writer<W>) -> Result<(), XmlError>;
@@ -71,9 +72,9 @@ impl<W: Write> WriterExt for Writer<W> {
         T: AsRef<[u8]>,
     {
         let name = name.as_ref();
-        self.write_event(Event::Start(BytesStart::borrowed(name, name.len())))?;
-        self.write_event(Event::Text(BytesText::from_escaped(text.as_ref())))?;
-        self.write_event(Event::End(BytesEnd::borrowed(name)))?;
+        self.write_event(Event::Start(BytesStart::borrowed(name, name.len()))).map_err(XmlError::new)?;
+        self.write_event(Event::Text(BytesText::from_escaped(text.as_ref()))).map_err(XmlError::new)?;
+        self.write_event(Event::End(BytesEnd::borrowed(name))).map_err(XmlError::new)?;
         Ok(())
     }
 

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -3,6 +3,8 @@ extern crate atom_syndication as atom;
 use std::fs::File;
 use std::io::BufReader;
 
+use atom::Error;
+
 use crate::atom::extension::ExtensionMap;
 use crate::atom::{Feed, Text};
 
@@ -168,4 +170,143 @@ fn read_extension() {
 
     check_extensions(feed.extensions());
     check_extensions(entry.extensions());
+}
+
+#[test]
+fn read_eof() {
+    let result = Feed::read_from("".as_bytes());
+    assert!(matches!(result, Err(Error::Eof)));
+}
+
+#[test]
+fn read_invalid_start() {
+    let result = Feed::read_from("<wrong></wrong>".as_bytes());
+    assert!(matches!(result, Err(Error::InvalidStartTag)));
+}
+
+#[test]
+fn read_invalid_attribute_lang() {
+    let result = Feed::read_from("<feed xml:lang=\"&;\"></feed>".as_bytes());
+    assert!(matches!(result, Err(Error::Xml(_))));
+}
+
+#[test]
+fn read_invalid_attribute_base() {
+    let result = Feed::read_from("<feed xml:base=\"&;\"></feed>".as_bytes());
+    assert!(matches!(result, Err(Error::Xml(_))));
+}
+
+#[test]
+fn read_invalid_attribute_namespace() {
+    let result = Feed::read_from("<feed xmlns:invalid=\"&;\"></feed>".as_bytes());
+    assert!(matches!(result, Err(Error::Xml(_))));
+}
+
+
+#[test]
+fn read_mismatched_tags() {
+    let result = Feed::read_from("<feed><a></b></feed>".as_bytes());
+    assert!(matches!(result, Err(Error::Xml(_))));
+}
+
+#[test]
+fn read_internal_invalid_tag() {
+    let result = Feed::read_from("<feed><aba><aaa></aba></feed>".as_bytes());
+    assert!(matches!(result, Err(Error::Xml(_))));
+}
+
+#[test]
+fn read_entry_internal_invalid_tag() {
+    let result = Feed::read_from("<feed><entry><aaa></entry></feed>".as_bytes());
+    assert!(matches!(result, Err(Error::Xml(_))));
+}
+
+#[test]
+fn link_invalid_attribute() {
+    let result = Feed::read_from("<feed><link href=\"&;\"></link></feed>".as_bytes());
+    assert!(matches!(result, Err(Error::Xml(_))));
+}
+
+#[test]
+fn text_invalid_xml_base() {
+    let result = Feed::read_from("<feed><rights xml:base=\"&;\"></rights></feed>".as_bytes());
+    assert!(matches!(result, Err(Error::Xml(_))));
+}
+
+#[test]
+fn text_invalid_xml_lang() {
+    let result = Feed::read_from("<feed><rights xml:lang=\"&;\"></rights></feed>".as_bytes());
+    assert!(matches!(result, Err(Error::Xml(_))));
+}
+
+#[test]
+fn text_invalid_type() {
+    let result = Feed::read_from("<feed><rights type=\"&;\"></rights></feed>".as_bytes());
+    assert!(matches!(result, Err(Error::Xml(_))));
+}
+
+#[test]
+fn author_internal_invalid_tag() {
+    let result = Feed::read_from("<feed><author><invalid></author></feed>".as_bytes());
+    assert!(matches!(result, Err(Error::Xml(_))));
+}
+
+#[test]
+fn source_internal_invalid_tag() {
+    let result = Feed::read_from("<feed><entry><source><invalid></source></entry></feed>".as_bytes());
+    assert!(matches!(result, Err(Error::Xml(_))));
+}
+
+#[test]
+fn content_invalid_xml_lang() {
+    let result = Feed::read_from("<feed><entry><content xml:lang=\"&;\"></content></entry></feed>".as_bytes());
+    assert!(matches!(result, Err(Error::Xml(_))));
+}
+
+#[test]
+fn content_invalid_xml_base() {
+    let result = Feed::read_from("<feed><entry><content xml:base=\"&;\"></content></entry></feed>".as_bytes());
+    assert!(matches!(result, Err(Error::Xml(_))));
+}
+
+#[test]
+fn content_invalid_type() {
+    let result = Feed::read_from("<feed><entry><content type=\"&;\"></content></entry></feed>".as_bytes());
+    assert!(matches!(result, Err(Error::Xml(_))));
+}
+
+#[test]
+fn content_invalid_src() {
+    let result = Feed::read_from("<feed><entry><content src=\"&;\"></content></entry></feed>".as_bytes());
+    assert!(matches!(result, Err(Error::Xml(_))));
+}
+
+#[test]
+fn category_invalid_term() {
+    let result = Feed::read_from("<feed><category term=\"&;\"></category></feed>".as_bytes());
+    assert!(matches!(result, Err(Error::Xml(_))));
+}
+
+#[test]
+fn category_invalid_scheme() {
+    let result = Feed::read_from("<feed><category scheme=\"&;\"></category></feed>".as_bytes());
+    assert!(matches!(result, Err(Error::Xml(_))));
+}
+
+#[test]
+fn category_invalid_label() {
+    let result = Feed::read_from("<feed><category label=\"&;\"></category></feed>".as_bytes());
+    assert!(matches!(result, Err(Error::Xml(_))));
+}
+
+#[test]
+fn generator_invalid_uri() {
+    let result = Feed::read_from("<feed><generator uri=\"&;\"></generator></feed>".as_bytes());
+    assert!(matches!(result, Err(Error::Xml(_))));
+}
+
+#[test]
+fn generator_invalid_version() {
+    let result = Feed::read_from("<feed><generator version=\"&;\"></generator></feed>".as_bytes());
+    assert!(matches!(result, Err(Error::Xml(_))));
 }


### PR DESCRIPTION
Should close #62 
Though I wonder if ToXml's return of quick_xml::Error might also need to be removed