### PR TITLE
Upgrade GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,14 +16,13 @@ jobs:
           - nightly
           - beta
           - stable
-          - 1.42.0
+          - 1.54.0
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
+    - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@v1
       with:
         toolchain: ${{ matrix.rust }}
-        override: true
     - name: Build
       run: |
         cargo build --all-targets --no-default-features --verbose

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -6,19 +6,16 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Install clippy
-        uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable
-          components: clippy
-      - uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all --all-features
+      - run: cargo clippy --all --all-features
   fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - name: Run fmt check
-        run: cargo fmt --all -- --check
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+      - run: cargo fmt --all -- --check

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,19 +9,10 @@ on:
 jobs:
   coverage:
     runs-on: ubuntu-latest
+    container:
+      image: xd009642/tarpaulin:latest
+      options: --security-opt seccomp=unconfined
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
-    - uses: actions-rs/install@v0.1
-      with:
-        crate: cargo-tarpaulin
-        use-tool-cache: true
-    - name: Run coverage
-      run: cargo tarpaulin -f -t 5 --out Xml -v -- --test-threads=1
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
-      with:
-        token: ${{secrets.CODECOV_TOKEN}}
+    - uses: actions/checkout@v3
+    - run: cargo tarpaulin -f -t 5 --out Xml -v -- --test-threads=1
+    - uses: codecov/codecov-action@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Wrap `quick_xml::XmlError` into a newtype [`#65`](https://github.com/rust-syndication/atom/pull/65)
 - Implement `std::error::Error` for `XmlError`. Mark helper traits as `pub(crate)` to prevent their accidental leakage to public API [`#66`](https://github.com/rust-syndication/atom/pull/66)
-- Bump MSRV (Minimum Supported Rust Version) from 1.40.0 to 1.42.0 [`#66`](https://github.com/rust-syndication/atom/pull/66)
+- Bump MSRV (Minimum Supported Rust Version) from 1.40.0 to 1.54.0 [`#66`](https://github.com/rust-syndication/atom/pull/66) and [`#69`](https://github.com/rust-syndication/atom/pull/69)
 
 ## 0.11.0 - 2021-10-20
 


### PR DESCRIPTION
- Bump MSRV to 1.54.0 to support macos 12 (XCode 14).
- Replace unsupported `action-rs/*` actions by alternatives.
