### PR TITLE
Enables the parsing of elements defined in another namespace in Person constructs

### DIFF
--- a/tests/data/person.xml
+++ b/tests/data/person.xml
@@ -3,5 +3,6 @@
 		<name>John Doe</name>
 		<email>johndoe@example.com</email>
 		<uri>http://example.com</uri>
+		<ext:name exattr="exvalue" xmlns:ext="http://www.example.com">Example Name</ext:name>
 	</author>
 </feed>

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -118,6 +118,17 @@ fn read_person() {
     assert_eq!(person.name(), "John Doe");
     assert_eq!(person.email(), Some("johndoe@example.com"));
     assert_eq!(person.uri(), Some("http://example.com"));
+
+    // Person extensions
+    assert!(person.extensions().contains_key("ext"));
+    let map = person.extensions().get("ext").unwrap();
+    assert!(map.contains_key("name"));
+    let name = map.get("name").unwrap().first().unwrap();
+    assert_eq!(name.value(), Some("Example Name"));
+    assert_eq!(
+        name.attrs().get("exattr").map(String::as_str),
+        Some("exvalue")
+    );
 }
 
 #[test]


### PR DESCRIPTION
According to the Atom 1.0 spec, foreign markup may be processed as children of `atom:entry`, `atom:feed`, or a Person construct. atom-syndication processes extensions in `entry` and `feed` but ignores foreign markup in Person elements. 

This PR extends the current handling of extensions to `Person`. I've tried to keep the API consistent, but please let me know if you'd like changes. 

Use case: I am parsing arXiv atom entries, which include an `affiliation` element like this:
```xml
<author>
   <name>G. G. Kacprzak</name>
   <arxiv:affiliation xmlns:arxiv="http://arxiv.org/schemas/atom">NMSU</arxiv:affiliation>
</author>
```



