### PR TITLE
Remove never crate and switch to Infallible type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,9 @@ diligent-date-parser = "0.1.3"
 quick-xml = { version = "0.38", features = ["encoding"] }
 chrono = { version = "0.4", default-features = false, features = ["alloc"] }
 derive_builder = { version = "0.20", optional = true }
-never = { version = "0.1", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [features]
 default = ["builders"]
-builders = ["derive_builder", "never"]
+builders = ["derive_builder"]
 with-serde = ["serde", "chrono/serde"]

--- a/src/category.rs
+++ b/src/category.rs
@@ -18,7 +18,7 @@ use crate::util::{attr_value, decode};
     builder(
         setter(into),
         default,
-        build_fn(name = "build_impl", private, error = "never::Never")
+        build_fn(name = "build_impl", private, error = "std::convert::Infallible")
     )
 )]
 pub struct Category {

--- a/src/content.rs
+++ b/src/content.rs
@@ -31,7 +31,7 @@ use crate::util::{atom_text, atom_xhtml, attr_value, decode};
     builder(
         setter(into),
         default,
-        build_fn(name = "build_impl", private, error = "never::Never")
+        build_fn(name = "build_impl", private, error = "std::convert::Infallible")
     )
 )]
 pub struct Content {

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -28,7 +28,7 @@ use crate::util::{atom_datetime, atom_text, decode, default_fixed_datetime, skip
     builder(
         setter(into),
         default,
-        build_fn(name = "build_impl", private, error = "never::Never")
+        build_fn(name = "build_impl", private, error = "std::convert::Infallible")
     )
 )]
 pub struct Entry {

--- a/src/extension/mod.rs
+++ b/src/extension/mod.rs
@@ -22,7 +22,7 @@ pub type ExtensionMap = BTreeMap<String, BTreeMap<String, Vec<Extension>>>;
     builder(
         setter(into),
         default,
-        build_fn(name = "build_impl", private, error = "never::Never")
+        build_fn(name = "build_impl", private, error = "std::convert::Infallible")
     )
 )]
 pub struct Extension {

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -49,7 +49,7 @@ impl Default for WriteConfig {
     builder(
         setter(into),
         default,
-        build_fn(name = "build_impl", private, error = "never::Never")
+        build_fn(name = "build_impl", private, error = "std::convert::Infallible")
     )
 )]
 pub struct Feed {

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -20,7 +20,7 @@ use crate::util::{atom_text, attr_value, decode};
     builder(
         setter(into),
         default,
-        build_fn(name = "build_impl", private, error = "never::Never")
+        build_fn(name = "build_impl", private, error = "std::convert::Infallible")
     )
 )]
 pub struct Generator {

--- a/src/link.rs
+++ b/src/link.rs
@@ -18,7 +18,7 @@ use crate::util::{attr_value, decode};
     builder(
         setter(into),
         default,
-        build_fn(name = "build_impl", private, error = "never::Never")
+        build_fn(name = "build_impl", private, error = "std::convert::Infallible")
     )
 )]
 pub struct Link {

--- a/src/person.rs
+++ b/src/person.rs
@@ -22,7 +22,7 @@ use crate::util::{atom_text, decode, skip};
     builder(
         setter(into),
         default,
-        build_fn(name = "build_impl", private, error = "never::Never")
+        build_fn(name = "build_impl", private, error = "std::convert::Infallible")
     )
 )]
 pub struct Person {

--- a/src/source.rs
+++ b/src/source.rs
@@ -25,7 +25,7 @@ use crate::util::{atom_datetime, atom_text, decode, default_fixed_datetime, skip
     builder(
         setter(into),
         default,
-        build_fn(name = "build_impl", private, error = "never::Never")
+        build_fn(name = "build_impl", private, error = "std::convert::Infallible")
     )
 )]
 pub struct Source {

--- a/src/text.rs
+++ b/src/text.rs
@@ -68,7 +68,7 @@ impl FromStr for TextType {
     builder(
         setter(into),
         default,
-        build_fn(name = "build_impl", private, error = "never::Never")
+        build_fn(name = "build_impl", private, error = "std::convert::Infallible")
     )
 )]
 /// Represents a [text construct](https://tools.ietf.org/html/rfc4287#section-3.1) in an Atom feed.


### PR DESCRIPTION
`atom_syndication` currently uses the never crate to provide a stable bottom/never type (`!`) while we wait for `!` to be stabilised. This is a library that appears essentially unmaintained (not that it's *too* much of a problem - not much code to maintain!), and has been deleted from the original repo (the upstream link in crates.io is a dead link to a file in the Fuchsia monorepo)

`atom_syndication` is only using the `never::Never` type to indicate an error, which the Rust standard library already provides in the form of `Infallible`. This is currently an empty struct with some trait implementations (much like `never::Never`), but upon stabilisation of `!` will be switched to a type alias. With a couple exceptions, this is forward compatible. We can switch to `Infallible` and drop a dependency. 

This makes my work a little easier as I'm currently packaging a dependent of `atom_syndication`, and by extension, `atom_syndication` itself, in the Fedora repos, and `never` has some license file weirdness which is a PITA. 