### PR TITLE
Upgrade to quick-xml 0.41

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 0.12.9 - 2026-07-03
+
+- Update `quick-xml` to `0.41` and migrate to the normalized quick-xml attribute API. [`#95`](https://github.com/rust-syndication/atom/pull/95)
+
 ## 0.12.8 - 2026-05-10
 
 - Enables the parsing of elements defined in another namespace in Person constructs [`#91`](https://github.com/rust-syndication/atom/pull/91)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.83"
 
 [dependencies]
 diligent-date-parser = "0.1.3"
-quick-xml = { version = "0.39", features = ["encoding"] }
+quick-xml = { version = "0.41", features = ["encoding"] }
 chrono = { version = "0.4", default-features = false, features = ["alloc"] }
 derive_builder = { version = "0.20", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atom_syndication"
-version = "0.12.8"
+version = "0.12.9"
 authors = ["James Hurst <jh.jameshurst@gmail.com>"]
 edition = "2021"
 description = "Library for serializing the Atom web content syndication format"

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,7 +2,7 @@ use quick_xml::{
     escape::{escape, resolve_predefined_entity},
     events::{attributes::Attribute, Event},
     name::QName,
-    Reader,
+    Reader, XmlVersion,
 };
 
 use crate::error::{Error, XmlError};
@@ -30,7 +30,7 @@ pub(crate) fn attr_value<'s, 'r, B: BufRead>(
     reader: &'r Reader<B>,
 ) -> Result<Cow<'s, str>, Error> {
     let value = attr
-        .decode_and_unescape_value(reader.decoder())
+        .decoded_and_normalized_value(XmlVersion::default(), reader.decoder())
         .map_err(XmlError::new)?;
     Ok(value)
 }


### PR DESCRIPTION
There have been two RustSec advisories for quick-xml:

- https://rustsec.org/advisories/RUSTSEC-2026-0194.html
- https://rustsec.org/advisories/RUSTSEC-2026-0195.html

So it would be nice to get this published.